### PR TITLE
Conflict Error cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All Error classes can be instantiated with custom `message`s and `status`es
 | `AuthenticationError` | `'Unauthorized'` | `401` | `'authentication_error'` |
 | `ForbiddenError` | `'Forbidden'` | `403` | `'forbidden_error'` |
 | `NotFoundError` | `'Not Found'` | `404` | `'not_found_error'` |
+| `ConflictError` | `'Conflict'` | `409` | `'conflict_error'` |
 | `RateLimitError` | `'Too many requests'` | `429` | `'rate_limit_error'` |
 | `InternalError` | `'Internal Server Error'` | `500` | `'internal_server_error'` |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { AuthenticationError } from './authenticationError';
 export { BadRequestError } from './badRequestError';
+export { ConflictError } from './conflictError';
 export { ForbiddenError } from './forbiddenError';
 export { InternalError } from './internalError';
 export { NotFoundError } from './notFoundError';


### PR DESCRIPTION
Adds export to `index` for direct importing (e.g. `import { ConflictError } from @foundryai/api-errors;`)

Documents class existence in README